### PR TITLE
Fix Double Free in KeyValues `#include` macro

### DIFF
--- a/src/tier1/KeyValues.cpp
+++ b/src/tier1/KeyValues.cpp
@@ -2306,15 +2306,9 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 	} while ( buf.IsValid() );
 
 	AppendIncludedKeys( includedKeys );
-	{
-		// delete included keys!
-		int i;
-		for ( i = includedKeys.Count() - 1; i > 0; i-- )
-		{
-			KeyValues *kv = includedKeys[ i ];
-			kv->deleteThis();
-		}
-	}
+	// DO NOT delete included keys!
+	// AppendIncludedKeys tacks them on without allocating.
+	// Only YOU can stop Fores.. Double Frees!
 
 	MergeBaseKeys( baseKeys );
 	{


### PR DESCRIPTION
I don't know if this is the bug that the [valvesoftware wiki mentions](https://developer.valvesoftware.com/wiki/KeyValues#About_KeyValues_Text_File_Format:), but I have experienced memory corruption and segfaults (in other source games) from this bug.